### PR TITLE
Content length patch

### DIFF
--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -368,6 +368,8 @@ add_content_headers("POST", Hdrs, Body, PartialUpload) ->
     add_content_headers(Hdrs, Body, PartialUpload);
 add_content_headers("PUT", Hdrs, Body, PartialUpload) ->
     add_content_headers(Hdrs, Body, PartialUpload);
+add_content_headers("PATCH", Hdrs, Body, PartialUpload) ->
+    add_content_headers(Hdrs, Body, PartialUpload);
 add_content_headers(_, Hdrs, _, _PartialUpload) ->
     Hdrs.
 

--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -370,6 +370,8 @@ add_content_headers("PUT", Hdrs, Body, PartialUpload) ->
     add_content_headers(Hdrs, Body, PartialUpload);
 add_content_headers("PATCH", Hdrs, Body, PartialUpload) ->
     add_content_headers(Hdrs, Body, PartialUpload);
+add_content_headers("DELETE", Hdrs, Body, PartialUpload) ->
+    add_content_headers(Hdrs, Body, PartialUpload);
 add_content_headers(_, Hdrs, _, _PartialUpload) ->
     Hdrs.
 


### PR DESCRIPTION
This fixes the missing content-length headers when sending PATCH or DELETE requests.
